### PR TITLE
Feature: eel-expression renderer

### DIFF
--- a/Classes/Fusion/ArrayRenderer.php
+++ b/Classes/Fusion/ArrayRenderer.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Prgfx\Fusion\TemplateLiterals\Fusion;
+
+use Neos\Flow\Annotations as Flow;
+
+class ArrayRenderer extends PlainTemplateLiterals
+{
+
+    /**
+     * The Fusion prototype wrapping the rendered code
+     * @Flow\InjectConfiguration("formatting.arrayRenderer.arrayPrototype")
+     * @var string
+     */
+    protected $arrayPrototype = 'Neos.Fusion:Join';
+
+    /**
+     * @Flow\InjectConfiguration("formatting.arrayRenderer.indentation")
+     * @var string
+     */
+    protected $indentation = '    ';
+
+    /**
+     * Generate fusion code given arguments the same way tagged template literals in javascript present their values
+     * @param string[] $stringParts
+     * @param string ...$expressions
+     * @return string
+     */
+    protected function generateCode(array $stringParts, ...$expressions)
+    {
+        if (empty($stringParts)) {
+            return "''";
+        }
+        if (count($stringParts) === 1) {
+            return '\'' . $this->escapeString($stringParts[0]) . '\'' . PHP_EOL;
+        }
+        if (count($expressions) === 1 && $stringParts[0] === '' && $stringParts[1] === '') {
+            return '${' . $expressions[0] . '}' . PHP_EOL;
+        }
+        $code = $this->arrayPrototype . ' {' . PHP_EOL;
+        for ($i = 0; $i < count($stringParts); $i++) {
+            $stringValue = $this->escapeString($stringParts[$i]);
+            if ($stringValue !== '') {
+                $code .= $this->indentation . $i . 's = \'' . $stringValue . '\'' . PHP_EOL;
+            }
+            if ($i < count($stringParts) && isset($expressions[$i])) {
+                $code .= $this->indentation . $i . 'v = ${' . $expressions[$i] . '}' . PHP_EOL;
+            }
+        }
+        $code .= '}' . PHP_EOL;
+        return $code;
+    }
+}

--- a/Classes/Fusion/PlainTemplateLiterals.php
+++ b/Classes/Fusion/PlainTemplateLiterals.php
@@ -17,19 +17,6 @@ class PlainTemplateLiterals implements DslInterface
     const BLOCKMODE_COMPRESS = 'compress';
 
     /**
-     * The Fusion prototype wrapping the rendered code
-     * @Flow\InjectConfiguration("formatting.arrayPrototype")
-     * @var string
-     */
-    protected $arrayPrototype = 'Neos.Fusion:Join';
-
-    /**
-     * @Flow\InjectConfiguration("formatting.indentation")
-     * @var string
-     */
-    protected $indentation = '    ';
-
-    /**
      * @Flow\InjectConfiguration("blockDelimiters")
      * @var array
      */
@@ -197,17 +184,19 @@ class PlainTemplateLiterals implements DslInterface
         if (count($expressions) === 1 && $stringParts[0] === '' && $stringParts[1] === '') {
             return '${' . $expressions[0] . '}' . PHP_EOL;
         }
-        $code = $this->arrayPrototype . ' {' . PHP_EOL;
+        $parts = [];
         for ($i = 0; $i < count($stringParts); $i++) {
             $stringValue = $this->escapeString($stringParts[$i]);
             if ($stringValue !== '') {
-                $code .= $this->indentation . $i . 's = \'' . $stringValue . '\'' . PHP_EOL;
+                $parts[] = '\'' . $stringValue . '\'';
             }
             if ($i < count($stringParts) && isset($expressions[$i])) {
-                $code .= $this->indentation . $i . 'v = ${' . $expressions[$i] . '}' . PHP_EOL;
+                $parts[] = '(' . $expressions[$i] . ')';
             }
         }
-        $code .= '}' . PHP_EOL;
+        $code = '${' . implode(' + ', $parts) . '}' . PHP_EOL;
+//        echo $code;
+//        die;
         return $code;
     }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,13 +1,15 @@
 Neos:
   Fusion:
     dsl:
-      plain: Prgfx\Fusion\TemplateLiterals\Fusion\PlainTemplateLiterals
+      inline: Prgfx\Fusion\TemplateLiterals\Fusion\PlainTemplateLiterals
+      plain: Prgfx\Fusion\TemplateLiterals\Fusion\ArrayRenderer
 Prgfx:
   Fusion:
     TemplateLiterals:
       formatting:
-        arrayPrototype: 'Neos.Fusion:Join'
-        indentation: '    '
+        arrayRenderer:
+          arrayPrototype: 'Neos.Fusion:Join'
+          indentation: '    '
       blockDelimiters:
         default: ''
         block: '|'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ p = Some.Example:Prototype {
 }
 ```
 
+This package comes with two implementations: an array-renderer (creating a fusion array-like object (e.g. `Neos.Fusion:Array` or `Neos.Fusion:Join` as per configuration)) and an eel-expression renderer.  
+The latter has the advantage that you may reference variables as `${this.variable}` as it would seem intuitive:
+```js
+trackingId = ${Configuration.setting(...)}
+snippet = inline`(w=> { w.qa=w.qa||[];w.qa.push('create', '${this.trackingId}');})(window);`
+```
+**However** this does not work well with multiline blocks as the eel expression does not properly output newlines. This would be fine for snippets like shown above with block mode `compress` (see below). (After all this package mainly targets such scenarios.)
+
 ## Multiline blocks
 Given a block-mode modifier in the first line (and nothing else in this line), multiline blocks may be interpreted differently.
 The block-mode modifier can be configured in `Prgfx.Fusion.TemplateLiterals.blockDelimiters` to your preferences.

--- a/Tests/Unit/ArrayRendererTest.php
+++ b/Tests/Unit/ArrayRendererTest.php
@@ -2,18 +2,18 @@
 namespace Prgfx\Fusion\TemplateLiterals\Tests\Unit;
 
 use Neos\Flow\Tests\UnitTestCase;
-use Prgfx\Fusion\TemplateLiterals\Fusion\PlainTemplateLiterals;
+use Prgfx\Fusion\TemplateLiterals\Fusion\ArrayRenderer;
 
-class PlainTemplateLiteralTest extends UnitTestCase
+class ArrayRendererTest extends UnitTestCase
 {
     /**
-     * @var PlainTemplateLiterals
+     * @var ArrayRenderer
      */
     protected $dsl;
 
     public function setUp()
     {
-        $this->dsl = new PlainTemplateLiterals();
+        $this->dsl = new ArrayRenderer();
     }
 
     /**

--- a/Tests/Unit/EelRendererTest.php
+++ b/Tests/Unit/EelRendererTest.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace Prgfx\Fusion\TemplateLiterals\Tests\Unit;
+
+
+use Neos\Flow\Tests\UnitTestCase;
+use Prgfx\Fusion\TemplateLiterals\Fusion\PlainTemplateLiterals;
+
+class EelRendererTest extends UnitTestCase
+{
+    /**
+     * @var PlainTemplateLiterals()
+     */
+    protected $dsl;
+
+    public function setUp()
+    {
+        $this->dsl = new PlainTemplateLiterals();
+    }
+
+    /**
+     * @test
+     */
+    public function testStringOnly()
+    {
+        $code = 'Just plain text';
+        $fusion = $this->dsl->transpile($code);
+        $this->assertEquals("'$code'" . PHP_EOL, $fusion);
+    }
+
+    /**
+     * @test
+     */
+    public function testBasicInterpolation()
+    {
+        $code = 'Basic string ${I18n.translate(\'Package:Source:key\')} and another ${1} interpolation';
+        $fusion = $this->dsl->transpile($code);
+        $expectedFusion = '${\'Basic string \' + (I18n.translate(\'Package:Source:key\')) + \' and another \' + (1) + \' interpolation\'}';
+        $this->assertEquals($expectedFusion . PHP_EOL, $fusion);
+    }
+
+    /**
+     * @test
+     */
+    public function testInterpolationAtEnd()
+    {
+        $code = 'Interpolation at end ${1}';
+        $fusion = $this->dsl->transpile($code);
+        $expectedFusion = '${\'Interpolation at end \' + (1)}';
+        $this->assertEquals($expectedFusion . PHP_EOL, $fusion);
+    }
+
+    /**
+     * @test
+     */
+    public function testInterpolationAtStart()
+    {
+        $code = '${0} Interpolation at start';
+        $fusion = $this->dsl->transpile($code);
+        $expectedFusion = '${(0) + \' Interpolation at start\'}';
+        $this->assertEquals($expectedFusion . PHP_EOL, $fusion);
+    }
+
+    /**
+     * @test
+     */
+    public function testAdjacentInterpolations()
+    {
+        $code = '${0}${1}';
+        $fusion = $this->dsl->transpile($code);
+        $expectedFusion = '${(0) + (1)}';
+        $this->assertEquals($expectedFusion . PHP_EOL, $fusion);
+    }
+
+}


### PR DESCRIPTION
Creates an eel-expression renderer, creating code like `${'string part ' + (variable)}` to reference variables from the current fusion object as `this.*`.
The new renderer/DSL is available as `inline`.

Moves the array rendering into its own implementation as the more intuitive eel renderer might be preferable.
However as the rendering does not work well with multiline blocks, the eel renderer is not made the default renderer.